### PR TITLE
Improved compilation compability on Linux

### DIFF
--- a/liblua/Makefile
+++ b/liblua/Makefile
@@ -103,7 +103,7 @@ freebsd:
 generic: $(ALL)
 
 linux:
-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl -lreadline"
+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl -lreadline -ltermcap -lncurses"
 
 macosx:
 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" SYSLIBS="-lreadline"


### PR DESCRIPTION
Compilation of Lua (proxmark3/liblua) on a currently updated Slackware Linux 14.2 x86_64 vanilla distribution will cause some errors, due to a missing flags in the Makefile. I noticed that adding the termcap library solves the problem.

I also found a thread ([http://lua.2524044.n2.nabble.com/readline-termcap-ncurses-td5726148.html](http://lua.2524044.n2.nabble.com/readline-termcap-ncurses-td5726148.html)) where other Linux distributions might have similar problems with Lua. Included version of liblua, derived from Lua 5.2.2, also seems to depend on the Termcap library and/or ncurses library.

Output:

```
bash-4.3$ make -C proxmark3
make: Går till katalogen "/home/github/iceman1001/proxmark3"
make -C client all
make[1]: Går till katalogen "/home/github/iceman1001/proxmark3/client"
Compiling liblua, using platform linux
cd ../liblua && make linux
make[2]: Går till katalogen "/home/github/iceman1001/proxmark3/liblua"
make all SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl -lreadline"
make[3]: Går till katalogen "/home/github/iceman1001/proxmark3/liblua"
gcc -O3 -Wall -DLUA_COMPAT_ALL -DLUA_USE_LINUX    -c -o lapi.o lapi.c
[...]
gcc -O3 -Wall -DLUA_COMPAT_ALL -DLUA_USE_LINUX    -c -o linit.o linit.c
ar rcu liblua.a lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o lauxlib.o lbaselib.o lbitlib.o lcorolib.o ldblib.o liolib.o lmathlib.o loslib.o lstrlib.o ltablib.o loadlib.o linit.o 
ranlib liblua.a
gcc -O3 -Wall -DLUA_COMPAT_ALL -DLUA_USE_LINUX    -c -o lua.o lua.c
gcc -o lua   lua.o liblua.a -lm -Wl,-E -ldl -lreadline 
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tputs'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tgoto'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tgetflag'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `UP'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tgetent'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tgetnum'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `PC'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tgetstr'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `BC'
collect2: fel: ld returnerade avslutningsstatus 1
Makefile:63: receptet för målet "lua" misslyckades
make[3]: *** [lua] Fel 1
make[3]: Lämnar katalogen "/home/github/iceman1001/proxmark3/liblua"
Makefile:106: receptet för målet "linux" misslyckades
make[2]: *** [linux] Fel 2
make[2]: Lämnar katalogen "/home/github/iceman1001/proxmark3/liblua"
Makefile:203: receptet för målet "lua_build" misslyckades
make[1]: *** [lua_build] Fel 2
make[1]: Lämnar katalogen "/home/github/iceman1001/proxmark3/client"
Makefile:12: receptet för målet "client/all" misslyckades
make: *** [client/all] Fel 2
make: Lämnar katalogen "/home/github/iceman1001/proxmark3"
```
