### PR TITLE
Addition of depending library flags...

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -58,6 +58,7 @@ else
     CXXFLAGS = $(shell pkg-config --cflags QtCore QtGui 2>/dev/null) -Wall -O3
     QTLDLIBS = $(shell pkg-config --libs QtCore QtGui 2>/dev/null)
     LUALIB +=  -ldl
+    LDLIBS +=  -ltermcap -lncurses
     MOC = $(shell pkg-config --variable=moc_location QtCore)
     # Below is a variant you can use if you have problems compiling with QT5 on ubuntu. see http://www.proxmark.org/forum/viewtopic.php?id=1661 for more info. 
     #MOC = /usr/lib/x86_64-linux-gnu/qt4/bin/moc


### PR DESCRIPTION
Inclusion of termcap library or ncurses library solves the compilation errors on some Linux distributions, for example a currently updated Slackware Linux 14.2 x86_64 vanilla distribution (which I run).

Output:

```
bash-4.3# make -C proxmark3
[...]
g++ -DQT_SHARED -I/usr/lib64/qt/include/QtGui -I/usr/lib64/qt/include/QtCore -Wall -O3 obj/proxmark3.o obj/uart.o obj/util.o obj/sleep.o obj/nonce2key/crapto1.o obj/nonce2key/crypto1.o obj/nonce2key/nonce2key.o obj/nonce2key/crypto1_bs.o obj/loclass/cipher.o obj/loclass/cipherutils.o obj/loclass/des.o obj/loclass/ikeys.o obj/loclass/elite_crack.o obj/loclass/fileutils.o obj/mifarehost.o obj/parity.o obj/crc.o obj/crc16.o obj/crc64.o obj/iso14443crc.o obj/iso15693tools.o obj/data.o obj/graph.o obj/ui.o obj/cmddata.o obj/lfdemod.o obj/cmdanalyse.o obj/cmdhf.o obj/cmdhf14a.o obj/cmdhf14b.o obj/cmdhf15.o obj/cmdhfepa.o obj/cmdhflegic.o obj/cmdhficlass.o obj/cmdhfmf.o obj/cmdhfmfu.o obj/cmdhfmfhard.o obj/cmdhfmfdes.o obj/cmdhftopaz.o obj/cmdhw.o obj/cmdlf.o obj/cmdlfio.o obj/cmdlfhid.o obj/cmdlfawid.o obj/cmdlfem4x.o obj/cmdlfhitag.o obj/cmdlfti.o obj/cmdparser.o obj/cmdmain.o obj/cmdlft55xx.o obj/cmdlfpcf7931.o obj/cmdlfviking.o obj/cmdlfpresco.o obj/cmdlfpyramid.o obj/cmdlfguard.o obj/cmdlfnedap.o obj/pm3_binlib.o obj/scripting.o obj/cmdscript.o obj/pm3_bitlib.o obj/aes.o obj/protocols.o obj/sha1.o obj/sha256.o obj/cmdcrc.o obj/reveng/preset.o obj/reveng/reveng.o obj/reveng/cli.o obj/reveng/bmpbit.o obj/reveng/model.o obj/reveng/poly.o obj/reveng/getopt.o obj/tea.o obj/prng.o obj/radixsort.o obj/bucketsort.o obj/proxgui.o obj/proxguiqt.o obj/proxguiqt.moc.o -L/opt/local/lib -L/usr/local/lib -lreadline -lpthread -lm ../liblua/liblua.a -ldl -L/usr/lib64/qt/lib -lQtGui -lQtCore -o proxmark3
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tgetstr'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tputs'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `BC'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tgetent'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tgetflag'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tgoto'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `UP'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `tgetnum'
/usr/lib64/gcc/x86_64-slackware-linux/5.3.0/../../../../lib64/libreadline.so: undefined reference to `PC'
collect2: fel: ld returnerade avslutningsstatus 1
Makefile:172: receptet för målet "proxmark3" misslyckades
make[1]: *** [proxmark3] Fel 1
make[1]: Lämnar katalogen "/home/github/iceman1001/proxmark3/client"
Makefile:12: receptet för målet "client/all" misslyckades
make: *** [client/all] Fel 2
make: Lämnar katalogen "/home/github/iceman1001/proxmark3"
```
