### PR TITLE
Fixing clang compilation warning

### DIFF
--- a/client/reveng/poly.c
+++ b/client/reveng/poly.c
@@ -140,7 +140,7 @@ filtop(FILE *input, unsigned long length, int flags, int bperhx) {
 	bmp_t accu = BMP_C(0);
 	bmp_t mask = bperhx == BMP_BIT ? ~BMP_C(0) : (BMP_C(1) << bperhx) - BMP_C(1);
 	unsigned long iter = 0UL, idx;
-	int cmask = ~(~0 << CHAR_BIT), c;
+	int cmask = (1 << CHAR_BIT) - 1, c;
 	int count = 0, ofs;
 	poly_t poly = PZERO;
 	if(bperhx == 0) return(poly);
@@ -205,7 +205,7 @@ strtop(const char *string, int flags, int bperhx) {
 	bmp_t accu;
 	bmp_t mask = bperhx == BMP_BIT ? ~BMP_C(0) : (BMP_C(1) << bperhx) - BMP_C(1);
 	int pass, count, ofs;
-	int cmask = ~(~0 << CHAR_BIT), c;
+	int cmask = (1 << CHAR_BIT) - 1 , c;
 	const char *s;
 
 	poly_t poly = PZERO;

--- a/zlib/inflate.c
+++ b/zlib/inflate.c
@@ -1523,7 +1523,8 @@ z_streamp strm;
 {
     struct inflate_state FAR *state;
 
-    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
+    if (strm == Z_NULL || strm->state == Z_NULL)
+        return (long)(((unsigned long)0 - 1) << 16);
     state = (struct inflate_state FAR *)strm->state;
     return ((long)(state->back) << 16) +
         (state->mode == COPY ? state->length :


### PR DESCRIPTION
  warning: shifting a negative signed value is undefined [-Wshift-negative-value]
