### PR TITLE
Fixing warning:

### DIFF
--- a/client/cmdhflegic.c
+++ b/client/cmdhflegic.c
@@ -527,8 +527,7 @@ int CmdLegicRfRawWrite(const char *Cmd) {
 		PrintAndLog("# changing the DCF is irreversible  #");
 		PrintAndLog("#####################################");
 		PrintAndLog("do youe really want to continue? y(es) n(o)");		
-		scanf(" %c", &answer);
-		if (answer == 'y' || answer == 'Y') {
+		if (scanf(" %c", &answer) > 0 && (answer == 'y' || answer == 'Y')) {
 			SendCommand(&c);
 			return 0;
 		}


### PR DESCRIPTION
```
warning: ignoring return va 'scanf', declared with attribute warn_unused_result [-Wunused-result]
```
