### PR TITLE
A few fixes

### DIFF
--- a/client/cmdhf.c
+++ b/client/cmdhf.c
@@ -789,7 +789,7 @@ static command_t CommandTable[] = {
 	{"14b",         CmdHF14B,         1, "{ ISO14443B RFIDs... }"},
 	{"15",          CmdHF15,          1, "{ ISO15693 RFIDs... }"},
 	{"epa",         CmdHFEPA,         1, "{ German Identification Card... }"},
-	{"legic",       CmdHFLegic,       0, "{ LEGIC RFIDs... }"},
+	{"legic",       CmdHFLegic,       1, "{ LEGIC RFIDs... }"},
 	{"iclass",      CmdHFiClass,      1, "{ ICLASS RFIDs... }"},
 	{"mf",      	CmdHFMF,		  1, "{ MIFARE RFIDs... }"},
 	{"mfu",         CmdHFMFUltra,     1, "{ MIFARE Ultralight RFIDs... }"},

--- a/client/cmdhflegic.c
+++ b/client/cmdhflegic.c
@@ -575,6 +575,9 @@ int CmdLegicCalcCrc8(const char *Cmd){
 		switch(param_getchar(Cmd, cmdp)) {
 		case 'b':
 		case 'B':
+			// it's possible for user to accidentally enter "b" parameter
+			// more than once - we have to clean previous malloc
+			if (data) free(data);
 			data = malloc(len);
 			if ( data == NULL ) {
 				PrintAndLog("Can't allocate memory. exiting");


### PR DESCRIPTION
This should fix a Coverity defect, allow use of an offline function in LEGIC module and, importantly, fix potential stack corruption in LEGIC CRC calculator. Previously, 'data' would get malloc'ed with len of 0, then used as if it was of non-zero length.
