### PR TITLE
Indentation fix

### DIFF
--- a/armsrc/iso14443b.c
+++ b/armsrc/iso14443b.c
@@ -1639,11 +1639,11 @@ void RAMFUNC SnoopIso14443b(void) {
 				if (triggered)
 					LogTrace(Uart.output, Uart.byteCnt, time_start, time_stop, NULL, TRUE);
 
-                /* And ready to receive another command. */
-                UartReset();
-                /* And also reset the demod code, which might have been */
-                /* false-triggered by the commands from the reader. */
-                DemodReset();
+				/* And ready to receive another command. */
+				UartReset();
+				/* And also reset the demod code, which might have been */
+				/* false-triggered by the commands from the reader. */
+				DemodReset();
 			} else {
 				time_start = GetCountSspClk() - time_0;
 			}

--- a/armsrc/iso14443b.c
+++ b/armsrc/iso14443b.c
@@ -1639,11 +1639,11 @@ void RAMFUNC SnoopIso14443b(void) {
 				if (triggered)
 					LogTrace(Uart.output, Uart.byteCnt, time_start, time_stop, NULL, TRUE);
 
-					/* And ready to receive another command. */
-					UartReset();
-					/* And also reset the demod code, which might have been */
-					/* false-triggered by the commands from the reader. */
-					DemodReset();
+                /* And ready to receive another command. */
+                UartReset();
+                /* And also reset the demod code, which might have been */
+                /* false-triggered by the commands from the reader. */
+                DemodReset();
 			} else {
 				time_start = GetCountSspClk() - time_0;
 			}

--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -141,10 +141,10 @@ void UsbPacketReceived(uint8_t *packet, int len) {
 				// Wait until flashing of page finishes
 				uint32_t sr;
 				while(!((sr = AT91C_BASE_EFC0->EFC_FSR) & AT91C_MC_FRDY));
-                if(sr & (AT91C_MC_LOCKE | AT91C_MC_PROGE)) {
-                    dont_ack = 1;
-                    cmd_send(CMD_NACK,sr,0,0,0,0);
-                }
+				if(sr & (AT91C_MC_LOCKE | AT91C_MC_PROGE)) {
+					dont_ack = 1;
+					cmd_send(CMD_NACK,sr,0,0,0,0);
+				}
 			}
 		} break;
       

--- a/bootrom/bootrom.c
+++ b/bootrom/bootrom.c
@@ -141,10 +141,10 @@ void UsbPacketReceived(uint8_t *packet, int len) {
 				// Wait until flashing of page finishes
 				uint32_t sr;
 				while(!((sr = AT91C_BASE_EFC0->EFC_FSR) & AT91C_MC_FRDY));
-					if(sr & (AT91C_MC_LOCKE | AT91C_MC_PROGE)) {
-						dont_ack = 1;
-						cmd_send(CMD_NACK,sr,0,0,0,0);
-					}
+                if(sr & (AT91C_MC_LOCKE | AT91C_MC_PROGE)) {
+                    dont_ack = 1;
+                    cmd_send(CMD_NACK,sr,0,0,0,0);
+                }
 			}
 		} break;
       

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -85,8 +85,8 @@ size_t removeParity(uint8_t *BitStream, size_t startIdx, uint8_t pLen, uint8_t p
 			case 2: if (BitStream[j]==0) return 0; break; //should be 1 spacer bit
 			default: //test parity
 				if (parityTest(parityWd, pLen, pType) == 0) 
-                    return 0; 
-                break;
+					return 0; 
+				break;
 		}
 		bitCnt+=(pLen-1);
 		parityWd = 0;

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -84,7 +84,9 @@ size_t removeParity(uint8_t *BitStream, size_t startIdx, uint8_t pLen, uint8_t p
 			case 3: if (BitStream[j]==1) return 0; break; //should be 0 spacer bit
 			case 2: if (BitStream[j]==0) return 0; break; //should be 1 spacer bit
 			default: //test parity
-				if (parityTest(parityWd, pLen, pType) == 0) return 0; break;
+				if (parityTest(parityWd, pLen, pType) == 0) 
+                    return 0; 
+                break;
 		}
 		bitCnt+=(pLen-1);
 		parityWd = 0;


### PR DESCRIPTION
I got several compiler errors due to misleading indentation. Since warnings are treated as errors, this is very annoying, so here's a fix.
