### PR TITLE
hf mf sim: Multiple fixes

### DIFF
--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -64,7 +64,7 @@ const manufactureName manufactureMapping[] = {
 	{ 0x17, "KSW Microtec GmbH Germany" },
 	{ 0x18, "ZMD AG Germany" },
 	{ 0x19, "XICOR, Inc. USA" },
-	{ 0x1A, "Sony Corporation Japan Identifier Company Country" },
+	{ 0x1A, "Sony Corporation Japan" },
 	{ 0x1B, "Malaysia Microelectronic Solutions Sdn. Bhd Malaysia" },
 	{ 0x1C, "Emosyn USA" },
 	{ 0x1D, "Shanghai Fudan Microelectronics Co. Ltd. P.R. China" },
@@ -94,7 +94,7 @@ const manufactureName manufactureMapping[] = {
 	{ 0x35, "Fraunhofer Institute for Photonic Microsystems Germany" },
 	{ 0x36, "IDS Microchip AG Switzerland" },
 	{ 0x37, "Kovio USA" },
-	{ 0x38, "HMT Microelectronic Ltd Switzerland Identifier Company Country" },
+	{ 0x38, "HMT Microelectronic Ltd Switzerland" },
 	{ 0x39, "Silicon Craft Technology Thailand" },
 	{ 0x3A, "Advanced Film Device Inc. Japan" },
 	{ 0x3B, "Nitecrest Ltd UK" },
@@ -106,7 +106,7 @@ const manufactureName manufactureMapping[] = {
 	{ 0x41, "Renesas Electronics Corporation Japan" },
 	{ 0x42, "3Alogics Inc Korea" },
 	{ 0x43, "Top TroniQ Asia Limited Hong Kong" },
-	{ 0x44, "Gentag Inc (USA) USA" },
+	{ 0x44, "Gentag Inc. USA" },
 	{ 0x00, "no tag-info available" } // must be the last entry
 };
 

--- a/client/nonce2key/nonce2key.c
+++ b/client/nonce2key/nonce2key.c
@@ -170,7 +170,18 @@ bool tryMfk32(nonces_t data, uint64_t *outputkey) {
 	bool isSuccess = FALSE;
 	uint8_t counter = 0;
 
+	printf("Recovering key for:\n");
+	printf("    uid: %08x\n",uid);
+	printf("     nt: %08x\n",nt);
+	printf(" {nr_0}: %08x\n",nr0_enc);
+	printf(" {ar_0}: %08x\n",ar0_enc);
+	printf(" {nr_1}: %08x\n",nr1_enc);
+	printf(" {ar_1}: %08x\n",ar1_enc);
+
+	printf("\nLFSR succesors of the tag challenge:\n");
 	uint32_t p64 = prng_successor(nt, 64);
+	printf("  nt': %08x\n", p64);
+	printf(" nt'': %08x\n", prng_successor(p64, 32));
 	
 	s = lfsr_recovery32(ar0_enc ^ p64, 0);
   
@@ -212,11 +223,24 @@ bool tryMfk32_moebius(nonces_t data, uint64_t *outputkey) {
 	bool isSuccess = FALSE;
 	int counter = 0;
 	
+	printf("Recovering key for:\n");
+	printf("    uid: %08x\n",uid);
+	printf("   nt_0: %08x\n",nt0);
+	printf(" {nr_0}: %08x\n",nr0_enc);
+	printf(" {ar_0}: %08x\n",ar0_enc);
+	printf("   nt_1: %08x\n",nt1);
+	printf(" {nr_1}: %08x\n",nr1_enc);
+	printf(" {ar_1}: %08x\n",ar1_enc);
+
 	//PrintAndLog("Enter mfkey32_moebius");
 	clock_t t1 = clock();
 
+	printf("\nLFSR succesors of the tag challenge:\n");
 	uint32_t p640 = prng_successor(nt0, 64);
 	uint32_t p641 = prng_successor(nt1, 64);
+	
+	printf("  nt': %08x\n", p640);
+	printf(" nt'': %08x\n", prng_successor(p640, 32));
 	
 	s = lfsr_recovery32(ar0_enc ^ p640, 0);
   


### PR DESCRIPTION
- Fix `hf mf sim` to use nonce_t structures, so key recovery works (#45)
- Increases verbosity on the key recovery functionality
- Fix use-after-free for k_sector
- Add help info on `e` option to `hf mf sim`
