### PR TITLE
hf {14a,mf} sim: Be less verbose by default, add option "m" to turn maths back on (Issue #45)

### DIFF
--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -143,7 +143,7 @@ int usage_hf_14a_sim(void) {
 //	PrintAndLog("    u     : 4, 7 or 10 byte UID");
 	PrintAndLog("    u     : 4, 7 byte UID");
 	PrintAndLog("    x     : (Optional) performs the 'reader attack', nr/ar attack against a legitimate reader");
-	PrintAndLog("    m     : (Optional) Show maths used for cracking reader. Useful for debugging.");
+	PrintAndLog("    v     : (Optional) show maths used for cracking reader. Useful for debugging.");
 	PrintAndLog("\n   sample : hf 14a sim t 1 u 11223344 x");
 	PrintAndLog("          : hf 14a sim t 1 u 11223344");
 	PrintAndLog("          : hf 14a sim t 1 u 11223344556677");
@@ -455,11 +455,6 @@ int CmdHF14ASim(const char *Cmd) {
 			case 'h':
 			case 'H':
 				return usage_hf_14a_sim();
-			case 'm':
-			case 'M':
-				showMaths = true;
-				cmdp++;
-				break;
 			case 't':
 			case 'T':
 				// Retrieve the tag type
@@ -483,6 +478,11 @@ int CmdHF14ASim(const char *Cmd) {
 					useUIDfromEML = FALSE;
 				}
 				cmdp += 2;
+				break;
+			case 'v':
+			case 'V':
+				showMaths = true;
+				cmdp++;
 				break;
 			case 'x':
 			case 'X':

--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -143,6 +143,7 @@ int usage_hf_14a_sim(void) {
 //	PrintAndLog("    u     : 4, 7 or 10 byte UID");
 	PrintAndLog("    u     : 4, 7 byte UID");
 	PrintAndLog("    x     : (Optional) performs the 'reader attack', nr/ar attack against a legitimate reader");
+	PrintAndLog("    m     : (Optional) Show maths used for cracking reader. Useful for debugging.");
 	PrintAndLog("\n   sample : hf 14a sim t 1 u 11223344 x");
 	PrintAndLog("          : hf 14a sim t 1 u 11223344");
 	PrintAndLog("          : hf 14a sim t 1 u 11223344556677");
@@ -447,12 +448,18 @@ int CmdHF14ASim(const char *Cmd) {
 	uint8_t uid[10] = {0,0,0,0,0,0,0,0,0,0};
 	int uidlen = 0;
 	bool useUIDfromEML = TRUE;
+	bool showMaths = false;
 
 	while(param_getchar(Cmd, cmdp) != 0x00) {
 		switch(param_getchar(Cmd, cmdp)) {
 			case 'h':
 			case 'H':
 				return usage_hf_14a_sim();
+			case 'm':
+			case 'M':
+				showMaths = true;
+				cmdp++;
+				break;
 			case 't':
 			case 'T':
 				// Retrieve the tag type
@@ -513,7 +520,7 @@ int CmdHF14ASim(const char *Cmd) {
 		if ( (resp.arg[0] & 0xffff) != CMD_SIMULATE_MIFARE_CARD ) break;
 			
 		memcpy( data, resp.d.asBytes, sizeof(data) );
-		readerAttack(data, TRUE);
+		readerAttack(data, TRUE, showMaths);
 	}
 	return 0;
 }

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -32,6 +32,7 @@ int usage_hf14_mf1ksim(void){
 	PrintAndLog("      i    (Optional) Interactive, means that console will not be returned until simulation finishes or is aborted");
 	PrintAndLog("      x    (Optional) Crack, performs the 'reader attack', nr/ar attack against a legitimate reader, fishes out the key(s)");
 	PrintAndLog("      e    (Optional) Fill simulator keys from what we crack");
+	PrintAndLog("      m    (Optional) Show maths used for cracking reader. Useful for debugging.");
 	PrintAndLog("samples:");
 	PrintAndLog("           hf mf sim u 0a0a0a0a");
 	PrintAndLog("           hf mf sim u 11223344556677");
@@ -1364,7 +1365,7 @@ int CmdHF14AMfChk(const char *Cmd) {
 #define ATTACK_KEY_COUNT 8
 sector *k_sector = NULL;
 uint8_t k_sectorsCount = 16;
-void readerAttack(nonces_t data[], bool setEmulatorMem) {
+void readerAttack(nonces_t data[], bool setEmulatorMem, bool showMaths) {
 
 	// initialize storage for found keys
 	if (k_sector == NULL)
@@ -1413,7 +1414,7 @@ void readerAttack(nonces_t data[], bool setEmulatorMem) {
 			}
 #endif
 			//moebius attack			
-			if (tryMfk32_moebius(data[i+ATTACK_KEY_COUNT], &key)) {
+			if (tryMfk32_moebius(data[i+ATTACK_KEY_COUNT], &key, showMaths)) {
 				uint8_t sectorNum = data[i+ATTACK_KEY_COUNT].sector;
 				uint8_t keyType = data[i+ATTACK_KEY_COUNT].keytype;
 
@@ -1449,10 +1450,13 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 	uint8_t uid[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 	uint8_t exitAfterNReads = 0;
 	uint8_t flags = (FLAG_UID_IN_EMUL | FLAG_4B_UID_IN_DATA);
-	int uidlen = 0;	
+	int uidlen = 0;
 	bool setEmulatorMem = false;
 	uint8_t cmdp = 0;
 	bool errors = false;
+
+	// If set to true, we should show our workings when doing NR_AR_ATTACK.
+	bool showMaths = false;
 
 	while(param_getchar(Cmd, cmdp) != 0x00) {
 		switch(param_getchar(Cmd, cmdp)) {
@@ -1467,6 +1471,11 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 		case 'i':
 		case 'I':
 			flags |= FLAG_INTERACTIVE;
+			cmdp++;
+			break;
+		case 'm':
+		case 'M':
+			showMaths = true;
 			cmdp++;
 			break;
 		case 'n':
@@ -1524,7 +1533,7 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 			if ( (resp.arg[0] & 0xffff) != CMD_SIMULATE_MIFARE_CARD ) break;
 
 			memcpy( data, resp.d.asBytes, sizeof(data) );			
-			readerAttack(data, setEmulatorMem);
+			readerAttack(data, setEmulatorMem, showMaths);
 		}
 		
 		if (k_sector != NULL) {

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -32,7 +32,7 @@ int usage_hf14_mf1ksim(void){
 	PrintAndLog("      i    (Optional) Interactive, means that console will not be returned until simulation finishes or is aborted");
 	PrintAndLog("      x    (Optional) Crack, performs the 'reader attack', nr/ar attack against a legitimate reader, fishes out the key(s)");
 	PrintAndLog("      e    (Optional) Fill simulator keys from what we crack");
-	PrintAndLog("      m    (Optional) Show maths used for cracking reader. Useful for debugging.");
+	PrintAndLog("      v    (Optional) Show maths used for cracking reader. Useful for debugging.");
 	PrintAndLog("samples:");
 	PrintAndLog("           hf mf sim u 0a0a0a0a");
 	PrintAndLog("           hf mf sim u 11223344556677");
@@ -1473,11 +1473,6 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 			flags |= FLAG_INTERACTIVE;
 			cmdp++;
 			break;
-		case 'm':
-		case 'M':
-			showMaths = true;
-			cmdp++;
-			break;
 		case 'n':
 		case 'N':
 			exitAfterNReads = param_get8(Cmd, cmdp+1);
@@ -1493,6 +1488,11 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 				default: return usage_hf14_mf1ksim();
 			}
 			cmdp +=2;
+			break;
+		case 'v':
+		case 'V':
+			showMaths = true;
+			cmdp++;
 			break;
 		case 'x':
 		case 'X':

--- a/client/cmdhfmf.h
+++ b/client/cmdhfmf.h
@@ -60,6 +60,6 @@ int CmdHF14AMfCLoad(const char* cmd);
 int CmdHF14AMfCSave(const char* cmd);
 int CmdHf14MfDecryptBytes(const char *Cmd);
 
-void readerAttack(nonces_t data[], bool setEmulatorMem);
+void readerAttack(nonces_t data[], bool setEmulatorMem, bool showMaths);
 void printKeyTable( uint8_t sectorscnt, sector *e_sector );
 #endif

--- a/client/nonce2key/nonce2key.c
+++ b/client/nonce2key/nonce2key.c
@@ -208,7 +208,7 @@ bool tryMfk32(nonces_t data, uint64_t *outputkey) {
 	return isSuccess;
 }
 
-bool tryMfk32_moebius(nonces_t data, uint64_t *outputkey) {
+bool tryMfk32_moebius(nonces_t data, uint64_t *outputkey, bool showMaths) {
 	struct Crypto1State *s, *t;
 	uint64_t outkey  = 0;
 	uint64_t key 	 = 0;			     // recovered key
@@ -223,24 +223,28 @@ bool tryMfk32_moebius(nonces_t data, uint64_t *outputkey) {
 	bool isSuccess = FALSE;
 	int counter = 0;
 	
-	printf("Recovering key for:\n");
-	printf("    uid: %08x\n",uid);
-	printf("   nt_0: %08x\n",nt0);
-	printf(" {nr_0}: %08x\n",nr0_enc);
-	printf(" {ar_0}: %08x\n",ar0_enc);
-	printf("   nt_1: %08x\n",nt1);
-	printf(" {nr_1}: %08x\n",nr1_enc);
-	printf(" {ar_1}: %08x\n",ar1_enc);
+	if (showMaths) {
+		printf("Recovering key for:\n");
+		printf("    uid: %08x\n", uid);
+		printf("   nt_0: %08x\n", nt0);
+		printf(" {nr_0}: %08x\n", nr0_enc);
+		printf(" {ar_0}: %08x\n", ar0_enc);
+		printf("   nt_1: %08x\n", nt1);
+		printf(" {nr_1}: %08x\n", nr1_enc);
+		printf(" {ar_1}: %08x\n", ar1_enc);
+	}
 
 	//PrintAndLog("Enter mfkey32_moebius");
 	clock_t t1 = clock();
 
-	printf("\nLFSR succesors of the tag challenge:\n");
 	uint32_t p640 = prng_successor(nt0, 64);
 	uint32_t p641 = prng_successor(nt1, 64);
 	
-	printf("  nt': %08x\n", p640);
-	printf(" nt'': %08x\n", prng_successor(p640, 32));
+	if (showMaths) {
+		printf("\nLFSR succesors of the tag challenge:\n");
+		printf("  nt': %08x\n", p640);
+		printf(" nt'': %08x\n", prng_successor(p640, 32));
+	}
 	
 	s = lfsr_recovery32(ar0_enc ^ p640, 0);
   

--- a/client/nonce2key/nonce2key.h
+++ b/client/nonce2key/nonce2key.h
@@ -28,7 +28,7 @@ extern int nonce2key_ex(uint8_t blockno, uint8_t keytype, uint32_t uid, uint32_t
 
 //iceman, added these to be able to crack key direct from "hf 14 sim" && "hf mf sim"
 bool tryMfk32(nonces_t data, uint64_t *outputkey );
-bool tryMfk32_moebius(nonces_t data, uint64_t *outputkey );  // <<-- this one has best success
+bool tryMfk32_moebius(nonces_t data, uint64_t *outputkey, bool showMaths );  // <<-- this one has best success
 int tryMfk64_ex(uint8_t *data, uint64_t *outputkey );
 int tryMfk64(uint32_t uid, uint32_t nt, uint32_t nr_enc, uint32_t ar_enc, uint32_t at_enc, uint64_t *outputkey);
 #endif


### PR DESCRIPTION
This adds an option `m` to `hf mf sim` and `hf 14a sim` to turn verbosity back on.  By default, we don't show the values / maths used to crack the key.
