### PR TITLE
Fix some missing include statements which impact using proxmark3 client as a library

### DIFF
--- a/client/nonce2key/nonce2key.h
+++ b/client/nonce2key/nonce2key.h
@@ -20,6 +20,7 @@
 #include "common.h"
 #include "mifare.h" 	// nonces_t struct
 #include "ui.h"			// PrintAndLog
+#include "util.h"       // FALSE / TRUE
 #include "proxmark3.h"
 #include "mifarehost.h"
 

--- a/client/util.c
+++ b/client/util.c
@@ -12,6 +12,8 @@
 #define MAX_BIN_BREAK_LENGTH   (3072+384+1)
 
 #ifndef _WIN32
+#include <sys/ttydefaults.h>
+
 int ukbhit(void) {
   int cnt = 0;
   int error;

--- a/client/util.h
+++ b/client/util.h
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <math.h>		// math.pow
+#include <time.h>       // time, gmtime
 #include "proxmark3.h"	// time_t
 #include "data.h"		// for FILE_PATH_SIZE
 


### PR DESCRIPTION
There's a number of imports which aren't explicitly included in each of the files where it is used.

As a result of the issue, I can't selectively include parts of the Proxmark3 client as a library.  This pull request corrects those issues.