### PR TITLE
Improved logic for determining the correct Frame Delay Time (FDT)

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -1604,9 +1604,16 @@ int EmSendCmd14443aRaw(uint8_t *resp, uint16_t respLen, bool correctionNeeded) {
 	// Modulate Manchester
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_ISO14443A | FPGA_HF_ISO14443A_TAGSIM_MOD);
 
-	// include correction bit if necessary
-	if (Uart.parityBits & 0x01) {
-		correctionNeeded = TRUE;
+	// Include correction bit if necessary
+	if (Uart.bitCount == 7)
+	{
+		// Short tags (7 bits) don't have parity, determine the correct value from MSB
+		correctionNeeded = Uart.output[0] & 0x40;
+	}
+	else
+	{
+		// The parity bits are left-aligned
+		correctionNeeded = Uart.parity[(Uart.len-1)/8] & (0x80 >> ((Uart.len-1) & 7));
 	}
 	// 1236, so correction bit needed
 	i = (correctionNeeded) ? 0 : 1;


### PR DESCRIPTION
Improved logic for determining the correct Frame Delay Time (FDT) based value based on the last bit transmitted by the PCD.

The original logic did not always use the correct value. This caused the anticollision protocol to fail when simulating a tag with HID Omnikey 5421 reader.

This patch makes the third parameter (correctionNeeded) irrelevant. The function prototype and calls to EmSendCmd14443aRaw should probably be refactored, too.