### PR TITLE
Remove unnecessary x86 SSE 4.2 popcnt GCC flag

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -7,7 +7,7 @@ include ../common/Makefile.common
 
 CC = gcc
 CXX = g++
-COMMON_FLAGS += -std=c99 -O3 -mpopcnt -march=native -g
+COMMON_FLAGS += -std=c99 -O3 -march=native -g
 
 #VPATH = ../common ../zlib
 OBJDIR = obj


### PR DESCRIPTION
-mpopcnt is only a valid flag for x86 platforms with SSE 4.2. Breaks on anything else, e.g. ARM
Builds/runs fine without this flag. I don't see any reference to popcnt instruction so I'm not sure what this is there for.