### PR TITLE
Fix crashes on amd systems when compiled with a intel cpu

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -7,7 +7,7 @@ include ../common/Makefile.common
 
 CC = gcc
 CXX = g++
-COMMON_FLAGS += -std=c99 -O3 -march=native -g
+COMMON_FLAGS += -std=c99 -O3 -g
 
 #VPATH = ../common ../zlib
 OBJDIR = obj


### PR DESCRIPTION
Fixes client crashes on start when compiled on an intel platform and run on a amd system.