### PR TITLE
Fixed udev makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ tarbin: newtarbin client/tarbin armsrc/tarbin bootrom/tarbin
 udev:
 	sudo cp -rf driver/77-mm-usb-device-blacklist.rules /etc/udev/rules.d/77-mm-usb-device-blacklist.rules
 	sudo udevadm control --reload-rules
-	sudo adduser $USER dialout
+	sudo adduser $(USER) dialout
  
 # easy printing of MAKE VARIABLES
 print-%: ; @echo $* = $($*) 


### PR DESCRIPTION
make udev was giving this error
```
sudo adduser SER dialout
adduser: The user `SER' does not exist.
Makefile:74: recipe for target 'udev' failed
```
due to missing parentheses