### PR TITLE
Enclosed naked statements with braces to avoid C compliler misleading-indentation 'guard' warning.

### DIFF
--- a/armsrc/felica.c
+++ b/armsrc/felica.c
@@ -395,8 +395,9 @@ static void sendNFCToFPGA(uint8_t * frame, int len, uint32_t waitTill, uint8_t p
 			AT91C_BASE_SSC->SSC_THR = 0x00;
 			c++;
 		}
-		if (AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_RXRDY))
+		if (AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_RXRDY)) {
 			b = (uint16_t)(AT91C_BASE_SSC->SSC_RHR); (void)b;
+		}
 	}
 
 	for(c = 0; c < len;) {
@@ -404,8 +405,9 @@ static void sendNFCToFPGA(uint8_t * frame, int len, uint32_t waitTill, uint8_t p
 			AT91C_BASE_SSC->SSC_THR = frame[c];
 			c++;
 		}
-		if (AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_RXRDY))
+		if (AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_RXRDY)) {
 			b = (uint16_t)(AT91C_BASE_SSC->SSC_RHR); (void)b;
+		}
 	}
 
 	while(!(AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_TXRDY))) {};
@@ -589,8 +591,9 @@ void HfDumpFelicaLiteS() {
     if(!crc_tabccitt_init)
         init_crcccitt_tab();
 
-    if(!manch_tbl_fill)
+    if(!manch_tbl_fill) {
         fillManch();
+    }
 	
 	ResetNFCFrame();
 


### PR DESCRIPTION
Getting the following error message when compiling:

<pre>felica.c: In function 'sendNFCToFPGA':
felica.c:398:3: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
   if (AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_RXRDY))
   ^~
felica.c:399:45: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
    b = (uint16_t)(AT91C_BASE_SSC->SSC_RHR); (void)b;
                                             ^
felica.c:407:3: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
   if (AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_RXRDY))
   ^~
felica.c:408:45: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
    b = (uint16_t)(AT91C_BASE_SSC->SSC_RHR); (void)b;
                                             ^
felica.c: In function 'HfDumpFelicaLiteS':
felica.c:592:5: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
     if(!manch_tbl_fill)
     ^~
felica.c:595:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  ResetNFCFrame();
  ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
../common/Makefile.common:88: recipe for target 'obj/felica.o' failed
</pre>