### PR TITLE
fix: misleading indentation

### DIFF
--- a/armsrc/felica.c
+++ b/armsrc/felica.c
@@ -576,7 +576,7 @@ void HfDumpFelicaLiteS() {
     if (!manch_tbl_fill)
         fillManch();
 	
-	ResetNFCFrame();
+    ResetNFCFrame();
 
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_ISO18092 | FPGA_HF_ISO18092_FLAG_READER |FPGA_HF_ISO18092_FLAG_NOMOD);
 


### PR DESCRIPTION
Fix for:
```
arm-none-eabi-gcc -c -I../include -I../common -Wall -Werror -pedantic -Wunused -std=c99 -DWITH_CRC -DWITH_ISO18092
 -DON_DEVICE -DWITH_LF -DWITH_HITAG -DWITH_ISO15693 -DWITH_LEGICRF -DWITH_ISO14443b -DWITH_ISO14443a -DWITH_ICLASS
 -DWITH_FELICA -DWITH_HFSNOOP -DWITH_HF_YOUNG -fno-strict-aliasing -ffunction-sections -fdata-sections -DZ_SOLO -DZ_PREFIX -DNO_GZIP -DZLIB_PM3_TUNED -I../zlib -I. -Os -mthumb-interwork -o obj/felica.o felica.c
felica.c: In function 'HfDumpFelicaLiteS':
felica.c:576:5: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
     if (!manch_tbl_fill)
     ^~
felica.c:579:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
  ResetNFCFrame();
  ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
```