### PR TITLE
Just some small changes in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,13 @@ FLASH_PORT=com3
 PATHSEP=\\#
 endif
 
-all clean: %: client/% bootrom/% armsrc/% recovery/%
+all clean: %: client/% bootrom/% armsrc/% recovery/% mfkey/% nonce2key/%
+
+mfkey/%: FORCE
+	$(MAKE) -C tools/mfkey $(patsubst mfkey/%,%,$@)
+
+nonce2key/%: FORCE
+	$(MAKE) -C tools/nonce2key $(patsubst nonce2key/%,%,$@)
 
 bootrom/%: FORCE
 	$(MAKE) -C bootrom $(patsubst bootrom/%,%,$@)
@@ -45,8 +51,10 @@ help:
 	@echo + flash-bootrom - Make bootrom and flash it
 	@echo + flash-os      - Make armsrc and flash os \(includes fpga\)
 	@echo + flash-all     - Make bootrom and armsrc and flash bootrom and os image
+	@echo + mfkey         - Make tools/mfkey
+	@echo + nounce2key    - Make tools/nounce2key
 	@echo +	clean         - Clean in bootrom, armsrc and the OS-specific host directory
-
+	
 client: client/all
 
 flash-bootrom: bootrom/obj/bootrom.elf $(FLASH_TOOL)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,10 +1,10 @@
 get_craptev1:
 #	wget http://crapto1.netgarage.org/craptev1-v1.0.tar.xz
-	wget http://crapto1.netgarage.org/craptev1-v1.1.tar.xz
+	wget -N http://crapto1.netgarage.org/craptev1-v1.1.tar.xz
 	tar Jxvf craptev1-v1.1.tar.xz
 
 get_crapto1:
-	wget http://crapto1.netgarage.org/crapto1-v3.3.tar.xz
+	wget -N http://crapto1.netgarage.org/crapto1-v3.3.tar.xz
 	mkdir crapto1-v3.3
 	tar Jxvf crapto1-v3.3.tar.xz -C crapto1-v3.3
 


### PR DESCRIPTION
added 'make mfkey' and 'make nonce2key', 'make all' now builds mfkey and nonce2key
FIX: craptev1-v1.1.tar.xz and crapto1-v3.3.tar.xz will be redownloaded even it exists
