### PR TITLE
Fixes #168

### DIFF
--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -69,7 +69,7 @@ struct receiver_arg {
 	int run;
 };
 
-#if defined(__linux__)
+#if defined(__linux__) || (__APPLE__)
 static void showBanner(void){
 	printf("\n\n");
 	printf("\e[34m██████╗ ███╗   ███╗ ████╗\e[0m     ...iceman fork\n");


### PR DESCRIPTION
Fixes #168 by adding `|| (__APPLE__)` to `showBanner()`'s if defined statement. Allows building via HomeBrew on MacOS