### PR TITLE
Minor warning correction.

### DIFF
--- a/client/ui.c
+++ b/client/ui.c
@@ -37,10 +37,10 @@ void PrintAndLogOptions(char *str[][2], size_t size, size_t space)
 		for(int j = 0; j < 2; j++)
 		{
 			if(j == 0)
-			    snprintf(format, sizeof(format), "%%%us%%%us", space, counts[j]);
+			    snprintf(format, sizeof(format), "%%%zus%%%zus", space, counts[j]);
             else
-                snprintf(format, sizeof(format), "%%%us%%-%us", space, counts[j]);
-			snprintf(buff + strlen(buff), sizeof(buff) - strlen(buff), format, " ", str[i][j]);		
+                snprintf(format, sizeof(format), "%%%zus%%-%zus", space, counts[j]);
+			snprintf(buff + strlen(buff), sizeof(buff) - strlen(buff), format, " ", str[i][j]);
 		}
 		if(i<size-1)
 			strncat(buff, "\n", sizeof(buff)-strlen(buff) -1);


### PR DESCRIPTION
This fix resolves the warnings as printed below. 

ui.c: In function ‘PrintAndLogOptions’:
ui.c:40:45: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘size_t {aka long unsigned int}’ [-Wformat=]
        snprintf(format, sizeof(format), "%%%us%%%us", space, counts[j]);
                                             ^
ui.c:40:50: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘size_t {aka long unsigned int}’ [-Wformat=]
        snprintf(format, sizeof(format), "%%%us%%%us", space, counts[j]);
                                                  ^
ui.c:42:54: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘size_t {aka long unsigned int}’ [-Wformat=]
                 snprintf(format, sizeof(format), "%%%us%%-%us", space, counts[j]);
                                                      ^
ui.c:42:60: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘size_t {aka long unsigned int}’ [-Wformat=]
                 snprintf(format, sizeof(format), "%%%us%%-%us", space, counts[j]);