### PR TITLE
Fixes KIGIV Standalone mode simulation

### DIFF
--- a/armsrc/Standalone/hf_colin.c
+++ b/armsrc/Standalone/hf_colin.c
@@ -607,7 +607,7 @@ failtag:
     vtsend_set_attribute(NULL, 5);
     DbprintfEx(FLAG_NOLOG, "[    SIMULATION   ]");
     vtsend_set_attribute(NULL, 0);
-    Mifare1ksim(0, 0, 0, NULL);
+    Mifare1ksim(0x12, 0, 0, NULL);
     vtsend_cursor_position_restore(NULL);
     DbprintfEx(FLAG_NOLOG, "[   SIMUL ENDED   ]%s", _GREEN_, _WHITE_);
     cjSetCursLeft();

--- a/armsrc/Standalone/hf_colin.c
+++ b/armsrc/Standalone/hf_colin.c
@@ -607,7 +607,7 @@ failtag:
     vtsend_set_attribute(NULL, 5);
     DbprintfEx(FLAG_NOLOG, "[    SIMULATION   ]");
     vtsend_set_attribute(NULL, 0);
-    Mifare1ksim(0x12, 0, 0, cjuid);
+    Mifare1ksim(FLAG_4B_UID_IN_DATA | FLAG_UID_IN_EMUL, 0, 0, cjuid);
     vtsend_cursor_position_restore(NULL);
     DbprintfEx(FLAG_NOLOG, "[   SIMUL ENDED   ]%s", _GREEN_, _WHITE_);
     cjSetCursLeft();

--- a/armsrc/Standalone/hf_colin.c
+++ b/armsrc/Standalone/hf_colin.c
@@ -607,7 +607,7 @@ failtag:
     vtsend_set_attribute(NULL, 5);
     DbprintfEx(FLAG_NOLOG, "[    SIMULATION   ]");
     vtsend_set_attribute(NULL, 0);
-    Mifare1ksim(0x12, 0, 0, NULL);
+    Mifare1ksim(0x12, 0, 0, cjuid);
     vtsend_cursor_position_restore(NULL);
     DbprintfEx(FLAG_NOLOG, "[   SIMUL ENDED   ]%s", _GREEN_, _WHITE_);
     cjSetCursLeft();


### PR DESCRIPTION
By settings correct flags for Mifare1ksim(); Used to be just as is (maybe was 0x10, but never should have been 0x0)