### PR TITLE
Fix USB device descriptor issue, set serial number to "iceman1001".

### DIFF
--- a/common/usb_cdc.c
+++ b/common/usb_cdc.c
@@ -388,7 +388,7 @@ static const char StrProduct[] = {
 };
 
 static const char StrSerialNumber[] = {
-	22,			// Length
+	14,			// Length
 	0x03,		// Type is string
 	'i', 0,
 	'c', 0,
@@ -396,10 +396,6 @@ static const char StrSerialNumber[] = {
 	'm', 0,
 	'a', 0,
 	'n', 0,
-	'1', 0,
-	'0', 0,
-	'0', 0,
-	'1', 0
 };
 
 // size includes their own field.

--- a/common/usb_cdc.c
+++ b/common/usb_cdc.c
@@ -372,18 +372,34 @@ static const char StrManufacturer[] = {
   'p',0,'r',0,'o',0,'x',0,'m',0,'a',0,'r',0,'k',0,'.',0,'o',0,'r',0,'g',0,
 };
 
+// Note: This matches upstream proxmark3 USB descriptors.
 static const char StrProduct[] = {
-	22,			// Length
+	20,			// Length
 	0x03,		// Type is string
-	'P',0,'M',0,'3',0,' ',0,'D',0,'e',0,'v',0,'i',0,'c',0,'e',0
+	'p', 0,
+	'r', 0,
+	'o', 0,
+	'x', 0,
+	'm', 0,
+	'a', 0,
+	'r', 0,
+	'k', 0,
+	'3', 0
 };
 
 static const char StrSerialNumber[] = {
-	8,			// Length
+	22,			// Length
 	0x03,		// Type is string
-	'8',0,
-	'8',0,
-	'8',0
+	'i', 0,
+	'c', 0,
+	'e', 0,
+	'm', 0,
+	'a', 0,
+	'n', 0,
+	'1', 0,
+	'0', 0,
+	'0', 0,
+	'1', 0
 };
 
 // size includes their own field.


### PR DESCRIPTION
This is a port of [upstream PR 565](https://github.com/Proxmark/proxmark3/pull/565), which addresses USB enumeration issues on some Android devices, described in https://github.com/Proxmark/proxmark3/pull/565#issuecomment-366430026. Still don't know why this is a problem, but this patch seems to fix things.

I also took the liberty of changing the serial number of the device to `iceman1001`, which should make it pretty obvious in `dmesg` and similar tools when someone is running this firmware:

```
[42548.700691] usb 3-13.2.2: new full-speed USB device number 28 using xhci_hcd
[42554.165609] usb 3-13.2.2: New USB device found, idVendor=9ac4, idProduct=4b8f, bcdDevice= 1.00
[42554.165614] usb 3-13.2.2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[42554.165617] usb 3-13.2.2: Product: proxmark3
[42554.165620] usb 3-13.2.2: Manufacturer: proxmark.org
[42554.165623] usb 3-13.2.2: SerialNumber: iceman1001
[42554.173866] cdc_acm 3-13.2.2:1.0: ttyACM0: USB ACM device
```