### PR TITLE
improve NEDAP-XS + standalone mode

### DIFF
--- a/armsrc/Makefile
+++ b/armsrc/Makefile
@@ -36,6 +36,7 @@ APP_CFLAGS = -DWITH_CRC \
 #-------------------------------------------------------
 #			 -DWITH_LF_ICERUN
 #			 -DWITH_LF_SAMYRUN
+#			 -DWITH_LF_NEDAPXS
 #			 -DWITH_LF_PROXBRUTE
 #			 -DWITH_LF_HIDBRUTE
 #			 -DWITH_HF_YOUNG
@@ -109,6 +110,7 @@ ARMSRC = fpgaloader.c \
 	lf_samyrun.c \
     vtsend.c 
 	#	lf_samyrun.c \
+	#	lf_nedapxs.c \
 	#	lf_hidbrute.c \
 	#	lf_proxbrute.c \
 	#	hf_mattyrun.c \

--- a/armsrc/Standalone/lf_nedapxs.c
+++ b/armsrc/Standalone/lf_nedapxs.c
@@ -1,0 +1,159 @@
+//-----------------------------------------------------------------------------
+// Florent Carli, 2018
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// main code for LF Nedap XS by Florent Carli
+//-----------------------------------------------------------------------------
+#include "lf_nedapxs.h"
+
+// fcarli's sniff and repeat routine for LF
+void RunMod() {
+	StandAloneMode();
+	FpgaDownloadAndGo(FPGA_BITSTREAM_LF);
+
+	uint8_t rawdump0[16];
+	uint8_t rawdump1[16];
+	uint8_t *rawdump = rawdump0;
+	int selected = 0;
+	int playing = 0;
+	int cardRead0 = 0;
+	int cardRead1 = 0;
+	int *cardRead;
+        cardRead = &cardRead0;
+
+	// Turn on selected LED
+	LED(selected + 1, 0);
+	
+	DbpString("WELCOME TO NEDAP-XS Standalone Mode !");
+	for (;;) {		
+		WDT_HIT();
+		
+		// exit from standalone mode, send a usbcommand.
+		if (usb_poll_validate_length()) break;
+
+		// Was our button held down or pressed?
+		int button_pressed = BUTTON_HELD(1000);
+		//SpinDelay(300);
+
+		// Button was held for a second, begin recording
+		if (button_pressed > 0 && *cardRead == 0) {
+			LEDsoff();
+			LED(selected + 1, 0);
+			LED(LED_RED2, 0);
+
+			// record
+			DbpString("[+] starting recording");
+
+			// wait for button to be released
+			while (BUTTON_PRESS())
+				WDT_HIT();
+			DbpString("[+] button released !");
+
+			/* need this delay to prevent catching some weird data */
+			SpinDelay(500);
+			CmdNEDAPdemodASK(1, rawdump, 0);
+			Dbprintf("[+] recorded %x %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", selected, rawdump[0],rawdump[1],rawdump[2],rawdump[3],rawdump[4],rawdump[5],rawdump[6],rawdump[7],rawdump[8],rawdump[9],rawdump[10],rawdump[11],rawdump[12],rawdump[13],rawdump[14],rawdump[15]);
+
+			LEDsoff();
+			LED(selected + 1, 0);
+			// Finished recording
+			// If we were previously playing, set playing off
+			// so next button push begins playing what we recorded
+			playing = 0;			
+			*cardRead = 1;	
+		}
+		else if (button_pressed > 0 && *cardRead == 1) {
+			LEDsoff();
+			LED(selected + 1, 0);
+			LED(LED_ORANGE, 0);
+
+			// cloning
+			Dbprintf("[+] cloning %x %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", selected, rawdump[0],rawdump[1],rawdump[2],rawdump[3],rawdump[4],rawdump[5],rawdump[6],rawdump[7],rawdump[8],rawdump[9],rawdump[10],rawdump[11],rawdump[12],rawdump[13],rawdump[14],rawdump[15]);
+
+			// wait for button to be released
+			while (BUTTON_PRESS())
+				WDT_HIT();
+			DbpString("[+] button released !");
+
+			/* need this delay to prevent catching some weird data */
+			SpinDelay(500);
+
+			CopyNEDAPtoT55x7(rawdump);
+			Dbprintf("[+] cloned %x %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", selected, rawdump[0],rawdump[1],rawdump[2],rawdump[3],rawdump[4],rawdump[5],rawdump[6],rawdump[7],rawdump[8],rawdump[9],rawdump[10],rawdump[11],rawdump[12],rawdump[13],rawdump[14],rawdump[15]);
+
+			LEDsoff();
+			LED(selected + 1, 0);
+			// Finished recording
+
+			// If we were previously playing, set playing off
+			// so next button push begins playing what we recorded
+			playing = 0;			
+			*cardRead = 0;			
+		}
+
+		// Change where to record (or begin playing)
+		else if (button_pressed) {
+			// Next option if we were previously playing
+			if (playing) {
+				if (selected == 0) {
+					rawdump = rawdump1;
+					selected = 1;
+					cardRead = &cardRead1;
+				} else {
+					rawdump = rawdump0;
+					selected = 0;
+					cardRead = &cardRead0;
+				}
+			}
+
+			playing = !playing;
+
+			LEDsoff();
+			LED(selected + 1, 0);
+
+			// Begin transmitting
+			if (playing) {
+				LED(LED_GREEN, 0);
+				DbpString("[+] playing");
+				// wait for button to be released
+				while (BUTTON_PRESS())
+					WDT_HIT();
+				
+				Dbprintf("[+] %x %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", selected, rawdump[0],rawdump[1],rawdump[2],rawdump[3],rawdump[4],rawdump[5],rawdump[6],rawdump[7],rawdump[8],rawdump[9],rawdump[10],rawdump[11],rawdump[12],rawdump[13],rawdump[14],rawdump[15]);
+
+				CmdNEDAPsimTAG(rawdump, false);		
+				DbpString("[+] done playing");
+				
+				if (BUTTON_HELD(1000) > 0) {
+					DbpString("[+] exiting");
+					LEDsoff();
+					return;
+				}
+
+				/* We pressed a button so ignore it here with a delay */
+				SpinDelay(300);
+
+				// when done, we're done playing, move to next option
+				if (selected == 0) {
+					rawdump = rawdump1;
+					selected = 1;
+					cardRead = &cardRead1;
+				} else {
+					rawdump = rawdump0;
+					selected = 0;
+					cardRead = &cardRead0;
+				}
+				playing = !playing;
+				LEDsoff();
+				LED(selected + 1, 0);
+			}
+			else {
+				while (BUTTON_PRESS())
+					WDT_HIT();
+			}
+		}
+	}
+}

--- a/armsrc/Standalone/lf_nedapxs.h
+++ b/armsrc/Standalone/lf_nedapxs.h
@@ -1,0 +1,17 @@
+//-----------------------------------------------------------------------------
+// Florent Carli, 2018
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// StandAlone Mod
+//-----------------------------------------------------------------------------
+
+#ifndef __LF_NEDAPXS_H
+#define __LF_NEDAPXS_H
+
+#include "standalone.h" // standalone definitions
+#include "apps.h" // debugstatements, lfops?
+
+#endif /* __LF_NEDAPXS_H */

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -428,6 +428,9 @@ void printStandAloneModes(void) {
 #if defined(WITH_LF_SAMYRUN)
 	DbpString("   LF HID26 standalone - aka SamyRun (Samy Kamkar)");
 #endif
+#if defined(WITH_LF_NEDAPXS)
+	DbpString("   LF Nedap XS standalone - (Florent Carli)");
+#endif
 #if defined(WITH_LF_PROXBRUTE)
 	DbpString("   LF HID ProxII bruteforce - aka Proxbrute (Brad Antoniewicz)");
 #endif 
@@ -1447,7 +1450,7 @@ void  __attribute__((noreturn)) AppMain(void) {
 * All standalone mod "main loop" should be the RunMod() function.
 * Since the standalone is either LF or HF, the somewhat bisarr defines below exists. 
 */			
-#if defined (WITH_LF) && ( defined (WITH_LF_SAMYRUN) || defined (WITH_LF_HIDBRUTE) || defined (WITH_LF_PROXBRUTE) )
+#if defined (WITH_LF) && ( defined (WITH_LF_SAMYRUN) || defined (WITH_LF_HIDBRUTE) || defined (WITH_LF_PROXBRUTE) || defined (WITH_LF_NEDAPXS) )
 			RunMod();
 #endif
 		

--- a/armsrc/apps.h
+++ b/armsrc/apps.h
@@ -86,15 +86,18 @@ void SimulateTagLowFrequency(int period, int gap, int ledcontrol);
 void SimulateTagLowFrequencyBidir(int divisor, int max_bitlen);
 void CmdHIDsimTAGEx(uint32_t hi, uint32_t lo, int ledcontrol, int numcycles);
 void CmdHIDsimTAG(uint32_t hi, uint32_t lo, int ledcontrol);
+void CmdNEDAPsimTAG(uint8_t *rawdump, int ledcontrol);
 void CmdFSKsimTAG(uint16_t arg1, uint16_t arg2, size_t size, uint8_t *BitStream);
 void CmdASKsimTag(uint16_t arg1, uint16_t arg2, size_t size, uint8_t *BitStream);
 void CmdPSKsimTag(uint16_t arg1, uint16_t arg2, size_t size, uint8_t *BitStream);
 void CmdHIDdemodFSK(int findone, uint32_t *high, uint32_t *low, int ledcontrol);
+void CmdNEDAPdemodASK(int findone, uint8_t *rawdump, int ledcontrol);
 void CmdAWIDdemodFSK(int findone, uint32_t *high, uint32_t *low, int ledcontrol); // Realtime demodulation mode for AWID26
 void CmdEM410xdemod(int findone, uint32_t *high, uint64_t *low, int ledcontrol);
 void CmdIOdemodFSK(int findone, uint32_t *high, uint32_t *low, int ledcontrol);
 void CopyIOtoT55x7(uint32_t hi, uint32_t lo); // Clone an ioProx card to T5557/T5567
 void CopyHIDtoT55x7(uint32_t hi2, uint32_t hi, uint32_t lo, uint8_t longFMT); // Clone an HID card to T5557/T5567
+void CopyNEDAPtoT55x7(uint8_t *rawdump);
 void CopyVikingtoT55xx(uint32_t block1, uint32_t block2, uint8_t Q5);
 void WriteEM410x(uint32_t card, uint32_t id_hi, uint32_t id_lo);
 void CopyIndala64toT55x7(uint32_t hi, uint32_t lo); // Clone Indala 64-bit tag by UID to T55x7

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -877,6 +877,7 @@ int CmdLFfind(const char *Cmd) {
 	}
 	
 	if (EM4x50Read("", false))	{ PrintAndLogEx(SUCCESS, "\nValid EM4x50 ID Found!"); return 1;}
+	if (CmdLFNedapDemod(""))	{ PrintAndLogEx(SUCCESS, "\nValid NEDAP ID Found!"); goto out;}
 	if (CmdAWIDDemod(""))		{ PrintAndLogEx(SUCCESS, "\nValid AWID ID Found!"); goto out;}
 	if (CmdEM410xDemod(""))		{ PrintAndLogEx(SUCCESS, "\nValid EM410x ID Found!"); goto out;}
 	if (CmdFdxDemod(""))		{ PrintAndLogEx(SUCCESS, "\nValid FDX-B ID Found!"); goto out;}	
@@ -886,7 +887,6 @@ int CmdLFfind(const char *Cmd) {
 	if (CmdIndalaDemod(""))		{ PrintAndLogEx(SUCCESS, "\nValid Indala ID Found!");  goto out;}
 	if (CmdIOProxDemod(""))		{ PrintAndLogEx(SUCCESS, "\nValid IO Prox ID Found!"); goto out;}
 	if (CmdJablotronDemod(""))	{ PrintAndLogEx(SUCCESS, "\nValid Jablotron ID Found!"); goto out;}
-	if (CmdLFNedapDemod(""))	{ PrintAndLogEx(SUCCESS, "\nValid NEDAP ID Found!"); goto out;}
 	if (CmdNexWatchDemod("")) 	{ PrintAndLogEx(SUCCESS, "\nValid NexWatch ID Found!"); goto out;}
 	if (CmdNoralsyDemod(""))	{ PrintAndLogEx(SUCCESS, "\nValid Noralsy ID Found!"); goto out;}
 	if (CmdPacDemod(""))		{ PrintAndLogEx(SUCCESS, "\nValid PAC/Stanley ID Found!"); goto out;}	

--- a/client/cmdlfnedap.c
+++ b/client/cmdlfnedap.c
@@ -13,14 +13,14 @@ static int CmdHelp(const char *Cmd);
 int usage_lf_nedap_clone(void){
 	PrintAndLogEx(NORMAL, "clone a NEDAP tag to a T55x7 tag.");
 	PrintAndLogEx(NORMAL, "");
-	PrintAndLogEx(NORMAL, "Usage: lf nedap clone [h] <Card-Number>");
+	PrintAndLogEx(NORMAL, "Usage: lf nedap clone [h] <Raw-dump>");
 	PrintAndLogEx(NORMAL, "Options:");
 	PrintAndLogEx(NORMAL, "      h             : This help");
-	PrintAndLogEx(NORMAL, "      <Card Number> : 24-bit value card number");
+	PrintAndLogEx(NORMAL, "      <Raw Dump> : 16-Byte hex value (FF...)");
 //	PrintAndLogEx(NORMAL, "      Q5            : optional - clone to Q5 (T5555) instead of T55x7 chip");
 	PrintAndLogEx(NORMAL, "");
 	PrintAndLogEx(NORMAL, "Examples:");
-	PrintAndLogEx(NORMAL, "       lf nedap clone 112233");
+	PrintAndLogEx(NORMAL, "       lf nedap clone ff939...........................");
 	return 0;
 }
 
@@ -28,13 +28,13 @@ int usage_lf_nedap_sim(void) {
 	PrintAndLogEx(NORMAL, "Enables simulation of NEDAP card with specified card number.");
 	PrintAndLogEx(NORMAL, "Simulation runs until the button is pressed or another USB command is issued.");
 	PrintAndLogEx(NORMAL, "");
-	PrintAndLogEx(NORMAL, "Usage:  lf nedap sim [h] <Card-Number>");
+	PrintAndLogEx(NORMAL, "Usage:  lf nedap sim [h] <Raw-dump>");
 	PrintAndLogEx(NORMAL, "Options:");
 	PrintAndLogEx(NORMAL, "      h               : This help");
-	PrintAndLogEx(NORMAL, "      <Card Number>   : 24-bit value card number");
+	PrintAndLogEx(NORMAL, "      <Raw Dump>   : 16-Byte hex value (FF...)");
 	PrintAndLogEx(NORMAL, "");
 	PrintAndLogEx(NORMAL, "Examples:");
-	PrintAndLogEx(NORMAL, "       lf nedap sim 112233");
+	PrintAndLogEx(NORMAL, "       lf nedap sim ff939...........................");
 	return 0;
 }
 
@@ -51,57 +51,6 @@ int detectNedap(uint8_t *dest, size_t *size) {
 	return (int) startIdx;
 }
 
-int GetNedapBits(uint32_t cn, uint8_t *nedapBits) {
-
-	uint8_t pre[128];
-	memset(pre, 0x00, sizeof(pre));
-
-	// preamble  1111 1111 10 = 0xFF8
-	num_to_bytebits(0xFF8, 12, pre);
-
-	// fixed tagtype code?  0010 1101 = 0x2D
-	num_to_bytebits(0x2D, 8, pre+10);
-	
-	// 46 encrypted bits - UNKNOWN ALGO
-	//    -- 16 bits checksum. Should be 4x4 checksum,  based on UID and 2 constant values.
-	//    -- 30 bits undocumented?  
-	//num_to_bytebits(cn, 46, pre+18);
-
-	//----from this part, the UID in clear text, with a 1bit ZERO as separator between bytes.
-	pre[64] = 0;
-	pre[73] = 0;
-	pre[82] = 0;
-	pre[91] = 0;
-	pre[100] = 0;
-	pre[109] = 0;
-	pre[118] = 0;
-	
-	// cardnumber (uid)
-	num_to_bytebits( (cn >>  0) & 0xFF, 8, pre+65);
-	num_to_bytebits( (cn >>  8) & 0xFF, 8, pre+74);
-	num_to_bytebits( (cn >> 16) & 0xFF, 8, pre+83);
-
-	// two ?
-	num_to_bytebits( 0, 8, pre+92);
-	num_to_bytebits( 0, 8, pre+101);
-	
-	// chksum 
-	num_to_bytebits( (0 >> 0) & 0xFF, 8, pre+110);
-	num_to_bytebits( (0 >> 8) & 0xFF, 8, pre+119);	
-
-	
-	// add paritybits	(bitsource, dest, sourcelen, paritylen, parityType (odd, even,)
-	addParity(pre, pre+64, 64, 8, 1);
-	addParity(pre+64, pre+64, 64, 8, 1);
-
-	pre[63] = GetParity( DemodBuffer, EVEN, 63);
-	pre[127] = GetParity( DemodBuffer+64, EVEN, 63);
-	
-	memcpy(nedapBits, pre, 128);
-
-	// 1111111110001011010000010110100011001001000010110101001101011001000110011010010000000000100001110001001000000001000101011100111
-	return 1;
-}
 /*
  - UID: 001630
  - i: 4071
@@ -235,46 +184,38 @@ int CmdLFNedapRead(const char *Cmd) {
 	lf_read(true, 12000);
 	return CmdLFNedapDemod(Cmd);
 }
-/*
+
 int CmdLFNedapClone(const char *Cmd) {
-
 	char cmdp = param_getchar(Cmd, 0);
-	if (strlen(Cmd) == 0 || cmdp == 'h' || cmdp == 'H') return usage_lf_nedap_clone();
+	if (strlen(Cmd) != 32 || cmdp == 'h' || cmdp == 'H') return usage_lf_nedap_clone();
 
-	uint32_t cardnumber=0, cn = 0;
+	char rawdump1[9]="";
+	char rawdump2[9]="";
+	char rawdump3[9]="";
+	char rawdump4[9]="";
 	uint32_t blocks[5];
-	uint8_t bits[128];
-	memset(bits, 0x00, sizeof(bits));
+	memcpy(rawdump1, Cmd + 0, 8);
+	memcpy(rawdump2, Cmd + 8, 8);
+	memcpy(rawdump3, Cmd + 16, 8);
+	memcpy(rawdump4, Cmd + 24, 8);
 
-	if (sscanf(Cmd, "%u", &cn ) != 1) return usage_lf_nedap_clone();
-
-	cardnumber = (cn & 0x00FFFFFF);
-	
-	if ( !GetNedapBits(cardnumber, bits)) {
-		PrintAndLogEx(WARNING, "Error with tag bitstream generation.");
-		return 1;
-	}	
-
-	((ASK/DIphase   data rawdemod ab 0 64 1 0
 	//NEDAP - compat mode, ASK/DIphase, data rate 64, 4 data blocks
-	// DI-pahse (CDP) T55x7_MODULATION_DIPHASE
-	blocks[0] = T55x7_MODULATION_DIPHASE | T55x7_BITRATE_RF_64 | 7 << T55x7_MAXBLOCK_SHIFT;
-
-	if (param_getchar(Cmd, 3) == 'Q' || param_getchar(Cmd, 3) == 'q')
-		blocks[0] = T5555_MODULATION_BIPHASE | T5555_INVERT_OUTPUT | T5555_SET_BITRATE(64) | 7 <<T5555_MAXBLOCK_SHIFT;
-
-	blocks[1] = bytebits_to_byte(bits, 32);
-	blocks[2] = bytebits_to_byte(bits + 32, 32);
-	blocks[3] = bytebits_to_byte(bits + 64, 32);
-	blocks[4] = bytebits_to_byte(bits + 96, 32);
-
-	PrintAndLogEx(NORMAL, "Preparing to clone NEDAP to T55x7 with card number: %u", cardnumber);
-	print_blocks(blocks, 5);
+	// DI-phase (CDP) T55x7_MODULATION_DIPHASE
+	blocks[0] = T55x7_BITRATE_RF_64 | T55x7_MODULATION_DIPHASE | 4 << T55x7_MAXBLOCK_SHIFT;
+	blocks[1] = strtoll(rawdump1, NULL, 16);
+	blocks[2] = strtoll(rawdump2, NULL, 16);
+	blocks[3] = strtoll(rawdump3, NULL, 16);
+	blocks[4] = strtoll(rawdump4, NULL, 16);
+	PrintAndLogEx(WARNING, "Preparing to clone NEDAP to T55x7 with raw dump: %s", Cmd);
+	PrintAndLogEx(WARNING, "Blk | Data ");
+	PrintAndLogEx(WARNING, "----+------------");
+	for (uint8_t i = 0; i<5; ++i)
+		PrintAndLogEx(NORMAL, " %02d | %08" PRIx32, i, blocks[i]);
 
 	UsbCommand resp;
 	UsbCommand c = {CMD_T55XX_WRITE_BLOCK, {0,0,0}};
 
-	for (uint8_t i = 0; i<5; ++i ) {
+	for (uint8_t i = 0; i<5; ++i) {
 		c.arg[0] = blocks[i];
 		c.arg[1] = i;
 		clearCommandBuffer();
@@ -284,21 +225,14 @@ int CmdLFNedapClone(const char *Cmd) {
 			return -1;
 		}
 	}
-    return 0;
+	return 0;
 }
-*/
 
 int CmdLFNedapSim(const char *Cmd) {
 
-	uint32_t cardnumber = 0, cn = 0;
-	
 	char cmdp = param_getchar(Cmd, 0);
-	if (strlen(Cmd) == 0 || cmdp == 'h' || cmdp == 'H') return usage_lf_nedap_sim();
+	if (strlen(Cmd) != 32 || cmdp == 'h' || cmdp == 'H') return usage_lf_nedap_sim();
 
-	if (sscanf(Cmd, "%u", &cn ) != 1) return usage_lf_nedap_sim();
-	
-	cardnumber = (cn & 0x00FFFFFF);
-	
 	uint8_t bs[128];
 	size_t size = sizeof(bs);
 	memset(bs, 0x00, size);
@@ -308,14 +242,22 @@ int CmdLFNedapSim(const char *Cmd) {
 	uint16_t arg1, arg2;
 	arg1 = clk << 8 | encoding;
 	arg2 = invert << 8 | separator;
-	
-	if ( !GetNedapBits(cardnumber, bs)) {
-		PrintAndLogEx(WARNING, "Error with tag bitstream generation.");
-		return 1;
-	}	
 
-	PrintAndLogEx(NORMAL, "bin  %s", sprint_bin_break(bs, 128, 32));
-	PrintAndLogEx(NORMAL, "Simulating Nedap - CardNumber: %u", cardnumber );
+	char rawdump1[9]="";
+	char rawdump2[9]="";
+	char rawdump3[9]="";
+	char rawdump4[9]="";
+	memcpy(rawdump1, Cmd+0, 8);
+	memcpy(rawdump2, Cmd+8, 8);
+	memcpy(rawdump3, Cmd+16, 8);
+	memcpy(rawdump4, Cmd+24, 8);
+	num_to_bytebits(strtoll(rawdump1, NULL, 16), 32, bs);
+	num_to_bytebits(strtoll(rawdump2, NULL, 16), 32, bs+32);
+	num_to_bytebits(strtoll(rawdump3, NULL, 16), 32, bs+64);
+	num_to_bytebits(strtoll(rawdump4, NULL, 16), 32, bs+96);
+
+	PrintAndLogEx(NORMAL, "Simulating Nedap - RawDump: %s%s%s%s", rawdump1,rawdump2,rawdump3,rawdump4);
+	PrintAndLogEx(NORMAL, "binary:  %s", sprint_bin_break(bs, 128, 128));
 	
 	UsbCommand c = {CMD_ASK_SIM_TAG, {arg1, arg2, size}};
 	memcpy(c.d.asBytes, bs, size);
@@ -375,8 +317,8 @@ static command_t CommandTable[] = {
     {"help",	CmdHelp,		1, "this help"},
 	{"demod",	CmdLFNedapDemod,0, "demodulate an Nedap tag from the GraphBuffer"},	
 	{"read",	CmdLFNedapRead, 0, "attempt to read and extract tag data"},
-//	{"clone",	CmdLFNedapClone,0, "<Card Number>  clone nedap tag"},
-	{"sim",		CmdLFNedapSim,  0, "simulate nedap tag"},
+	{"clone",       CmdLFNedapClone,0, "<Raw Dump> clone nedap tag"},
+	{"sim",		CmdLFNedapSim,  0, "<Raw Dump> simulate nedap tag"},
 	{"chk",		CmdLFNedapChk,	1, "calculate Nedap Checksum <uid bytes>"},
     {NULL, NULL, 0, NULL}
 };

--- a/common/lfdemod.h
+++ b/common/lfdemod.h
@@ -76,6 +76,7 @@ extern size_t   removeParity(uint8_t *bits, size_t startIdx, uint8_t pLen, uint8
 extern int detectAWID(uint8_t *dest, size_t *size, int *waveStartIdx);
 extern int Em410xDecode(uint8_t *dest, size_t *size, size_t *startIdx, uint32_t *hi, uint64_t *lo);
 extern int HIDdemodFSK(uint8_t *dest, size_t *size, uint32_t *hi2, uint32_t *hi, uint32_t *lo, int *waveStartIdx);
+extern int NEDAPdemodASK(uint8_t *dest, size_t *size, int *waveStartIdx);
 extern int detectIdteck(uint8_t *dest, size_t *size);
 extern int detectIOProx(uint8_t *dest, size_t *size, int *waveStartIdx);
 #endif


### PR DESCRIPTION
Some changes I had to do to be able to read/sim/clone NEDAP XS tags, following up on this thread : http://www.proxmark.org/forum/viewtopic.php?id=2364
Note that you cannot simulate/clone having only the tagID, but you can with the full "raw dump" (which is the first major point of this PR).

Second part of this PR is a standalone mode for NEDAP-XS. Recording, simulating and cloning are working.

I would love to hear your comments and whether part of this PR is mergeable.