### PR TITLE
Added option -s -stay

### DIFF
--- a/client/proxgui.cpp
+++ b/client/proxgui.cpp
@@ -15,7 +15,7 @@
 static ProxGuiQT *gui = NULL;
 static WorkerThread *main_loop_thread = NULL;
 
-WorkerThread::WorkerThread(char *script_cmds_file, char *script_cmd, bool usb_present) : script_cmds_file(script_cmds_file), script_cmd(script_cmd), usb_present(usb_present)
+WorkerThread::WorkerThread(char *script_cmds_file, char *script_cmd, bool usb_present, bool stayInCommandLoop) : script_cmds_file(script_cmds_file), script_cmd(script_cmd), usb_present(usb_present), stayInCommandLoop(stayInCommandLoop)
 {
 }
 
@@ -24,7 +24,7 @@ WorkerThread::~WorkerThread()
 }
 
 void WorkerThread::run() {
-	main_loop(script_cmds_file, script_cmd, usb_present);
+	main_loop(script_cmds_file, script_cmd, usb_present, stayInCommandLoop);
 }
 
 extern "C" void ShowGraphWindow(void)
@@ -59,13 +59,13 @@ extern "C" void MainGraphics(void)
 	gui->MainLoop();
 }
 
-extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, char *script_cmd, bool usb_present)
+extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, char *script_cmd, bool usb_present, bool stayInCommandLoop)
 {
 #ifdef Q_WS_X11
 	if (getenv("DISPLAY") == NULL)
 		return;
 #endif
-	main_loop_thread = new WorkerThread(script_cmds_file, script_cmd, usb_present);
+	main_loop_thread = new WorkerThread(script_cmds_file, script_cmd, usb_present, stayInCommandLoop);
 	gui = new ProxGuiQT(argc, argv, main_loop_thread);
 }
 

--- a/client/proxgui.h
+++ b/client/proxgui.h
@@ -19,7 +19,7 @@ void ShowGraphWindow(void);
 void HideGraphWindow(void);
 void RepaintGraphWindow(void);
 void MainGraphics(void);
-void InitGraphics(int argc, char **argv, char *script_cmds_file, char *script_cmd, bool usb_present);
+void InitGraphics(int argc, char **argv, char *script_cmds_file, char *script_cmd, bool usb_present, bool stayInCommandLoop);
 void ExitGraphics(void);
 #ifndef MAX_GRAPH_TRACE_LEN
 #define MAX_GRAPH_TRACE_LEN (40000 * 8)

--- a/client/proxguiqt.h
+++ b/client/proxguiqt.h
@@ -95,13 +95,14 @@ class ProxWidget : public QWidget
 class WorkerThread : public QThread {
 		Q_OBJECT;
 	public:
-		WorkerThread(char*, char*, bool);
+		WorkerThread(char*, char*, bool, bool);
 		~WorkerThread();
 		void run();
 	private:
 		char *script_cmds_file = NULL;
 		char *script_cmd = NULL;
 		bool usb_present;
+		bool stayInCommandLoop;
 };
 
 class ProxGuiQT : public QObject

--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -351,7 +351,7 @@ static void set_my_executable_path(void) {
 }
 
 static void show_help(bool showFullHelp, char *command_line){
-	PrintAndLogEx(NORMAL, "syntax: %s <port> [-h|-help|-m|-f|-flush|-w|-wait|-c|-command|-l|-lua|-s|-stay] [cmd_script_file_name] [command][lua_script_name]\n", command_line);
+	PrintAndLogEx(NORMAL, "syntax: %s <port> [-h|-help|-m|-f|-flush|-w|-wait|-c|-command|-l|-lua|-k] [cmd_script_file_name] [command][lua_script_name]\n", command_line);
 	PrintAndLogEx(NORMAL, "\texample:'%s "SERIAL_PORT_H"'\n\n", command_line);
 	
 	if (showFullHelp){
@@ -369,9 +369,8 @@ static void show_help(bool showFullHelp, char *command_line){
 		PrintAndLogEx(NORMAL, "\t%s "SERIAL_PORT_H" -command \"hf mf nested 1 *\"\n\n", command_line);
 		PrintAndLogEx(NORMAL, "lua: <-l|-lua> Execute lua script.\n");
 		PrintAndLogEx(NORMAL, "\t%s "SERIAL_PORT_H" -l hf_read\n\n", command_line);
-		PrintAndLogEx(NORMAL, "stay: <-s|-stay> Stay in the command loop after script/command/lua execution.\n");
-		PrintAndLogEx(NORMAL, "\t%s "SERIAL_PORT_H" -s scriptfile\n\n", command_line);
-		PrintAndLogEx(NORMAL, "\t%s "SERIAL_PORT_H" -stay -l hf_read\n\n", command_line);
+		PrintAndLogEx(NORMAL, "stay: <-k> Stay in the command loop after script/command/lua execution.\n");
+		PrintAndLogEx(NORMAL, "\t%s "SERIAL_PORT_H" -k scriptfile\n\n", command_line);
 	}
 }
 
@@ -436,7 +435,7 @@ int main(int argc, char* argv[]) {
 		}
 		
 		// stay in command loop
-		if(strcmp(argv[i], "-s") == 0 || strcmp(argv[i], "-stay") == 0){
+		if(strcmp(argv[i], "-k") == 0){
 			stayInCommandLoop = true;
 		}
 	}

--- a/client/proxmark3.h
+++ b/client/proxmark3.h
@@ -24,7 +24,7 @@ extern "C" {
 void SendCommand(UsbCommand *c);
 const char *get_my_executable_path(void);
 const char *get_my_executable_directory(void);
-void main_loop(char *script_cmds_file, char *script_cmd, bool usb_present);
+void main_loop(char *script_cmds_file, char *script_cmd, bool usb_present, bool stayInCommandLoop);
 
 bool hookUpPM3(void);
 void *uart_receiver(void *targ);


### PR DESCRIPTION
I added option -s -stay to stay in the command loop after script/command/lua execution.

This allows for the automatic execution of commands when proxmarx3 is launched, and to remain in the command loop so that manual commands can be executed.

For example: proxmark3.exe com3 -s -c "rem Starting"
This will execute command "rem Starting", logging a timestamp in proxmark3.log.
With this, users who want some timestamp in the log can have this automatically by using this new option, while users who don't want a change to the log format will not be forced to adopt this.

![image](https://user-images.githubusercontent.com/6815601/45252346-00b11f00-b355-11e8-918e-09fd95267ee9.png)
