### PR TITLE
fix printing percentage character to be standard compliant

### DIFF
--- a/client/cmdhw.c
+++ b/client/cmdhw.c
@@ -74,7 +74,7 @@ static void lookupChipID(uint32_t iChipID, uint32_t mem_used) {
 	if ( mem_avail > 0 ) 
 		mem_left = (mem_avail * 1024) - mem_used;
 	
-	PrintAndLogEx(NORMAL, "  --= Nonvolatile Program Memory Size: %uK bytes, Used: %u bytes (%2.0f\%) Free: %u bytes (%2.0f\%)", 
+	PrintAndLogEx(NORMAL, "  --= Nonvolatile Program Memory Size: %uK bytes, Used: %u bytes (%2.0f%%) Free: %u bytes (%2.0f%%)",
 				mem_avail, 
 				mem_used, 
 				mem_avail == 0 ? 0.0f : (float)mem_used/(mem_avail*1024)*100,

--- a/client/ui.c
+++ b/client/ui.c
@@ -45,7 +45,7 @@ void PrintAndLogOptions(char *str[][2], size_t size, size_t space) {
 		if(i<size-1)
 			strncat(buff, "\n", sizeof(buff)-strlen(buff) -1);
     }
-    PrintAndLogEx(NORMAL, buff);
+    PrintAndLogEx(NORMAL, "%s", buff);
 }
 void PrintAndLogEx(logLevel_t level, char *fmt, ...) {
 
@@ -86,7 +86,7 @@ void PrintAndLogEx(logLevel_t level, char *fmt, ...) {
 
 	// no prefixes for normal
 	if ( level == NORMAL ) {
-		PrintAndLog(buffer);
+		PrintAndLog("%s", buffer);
 		return;
 	}
 	
@@ -111,10 +111,10 @@ void PrintAndLogEx(logLevel_t level, char *fmt, ...) {
 			
 			token = strtok(NULL, delim);
 		}
-		PrintAndLog(buffer2);
+		PrintAndLog("%s", buffer2);
 	} else {
 		snprintf(buffer2, sizeof(buffer2), "%s%s", prefix, buffer);
-		PrintAndLog(buffer2);
+		PrintAndLog("%s", buffer2);
 	}
 }
 


### PR DESCRIPTION
Using \% is glibc extension and does not work in all systems.

This changes PrintAndLogEx() to call the underlying function so that
percent is not exapanded any more, and we can use the standard
%% to express percent character.