### PR TITLE
uart_posix: fix missing SOL_TCP for macOS

### DIFF
--- a/uart/uart_posix.c
+++ b/uart/uart_posix.c
@@ -55,6 +55,9 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 
+#ifndef SOL_TCP
+#define SOL_TCP IPPROTO_TCP
+#endif
 
 typedef struct termios term_info;
 typedef struct {


### PR DESCRIPTION
macOS (at least 10.13) doesn't define SOL_TCP.
IPPROTO_TCP is the equivalent.