### PR TITLE
Add Global HID iCLASS key released by @AmmonRa at Kiwicon X

### DIFF
--- a/client/default_iclass_keys.dic
+++ b/client/default_iclass_keys.dic
@@ -8,3 +8,4 @@ AEA684A6DAB23278 -- AA1
 5b7c62c491c11b39 -- from loclass demo file.
 F0E1D2C3B4A59687 -- Kd from PicoPass 2k documentation
 5CBCF1DA45D5FB4F -- PicoPass Default Exchange Key
+3F90EBF0910F7B6F -- Global HID iCLASS key (thx @AmmonRa - Kiwicon X)


### PR DESCRIPTION
Add Global HID iCLASS key (released by @ammonra at Kiwicon X) to the default iclass keys dictionary file