### PR TITLE
Add support for 36bit HID tags, extend calcWiegand to include OEM bits

### DIFF
--- a/client/cmdlfhid.c
+++ b/client/cmdlfhid.c
@@ -108,7 +108,7 @@ static bool sendTry(uint8_t fmtlen, uint32_t fc, uint32_t cn, uint32_t delay, ui
 	if ( verbose )
 		PrintAndLogEx(NORMAL, "Trying FC: %u; CN: %u", fc, cn);
 	
-	calcWiegand( fmtlen, fc, cn, bits);
+	calcWiegand( fmtlen, fc, cn, bits, 0);
 
 	uint64_t arg1 = bytebits_to_byte(bits, 32);
 	uint64_t arg2 = bytebits_to_byte(bits + 32, 32);
@@ -169,6 +169,7 @@ int CmdHIDDemod(const char *Cmd) {
 		uint8_t fmtLen = 0;
 		uint32_t fc = 0;
 		uint32_t cardnum = 0;
+		uint8_t oem = 0;
 		if ((( hi >> 5) & 1) == 1){//if bit 38 is set then < 37 bit format is used
 			uint32_t lo2=0;
 			lo2=(((hi & 31) << 12) | (lo >> 20)); //get bits 21-37 to check for format len bit
@@ -192,6 +193,11 @@ int CmdHIDDemod(const char *Cmd) {
 				cardnum = (lo >> 1) & 0xFFFFF;
 				fc = ((hi & 1) << 11 ) | (lo >> 21);
 			}
+			if(fmtLen==36){
+				oem = (lo >> 1) & 0x3;
+				cardnum = (lo >> 3) & 0xFFFF;
+				fc = (hi & 0x7) << 13 | ((lo >> 19) & 0xFFFF);
+			}
 		}
 		else { //if bit 38 is not set then 37 bit format is used
 			fmtLen = 37;
@@ -202,7 +208,8 @@ int CmdHIDDemod(const char *Cmd) {
 				fc = ((hi & 0xF) << 12) | (lo >> 20);
 			}
 		}
-		PrintAndLogEx(NORMAL, "HID Prox TAG ID: %x%08x (%u) - Format Len: %ubit - FC: %u - Card: %u", hi, lo, (lo>>1) & 0xFFFF, fmtLen, fc, cardnum);
+		PrintAndLogEx(NORMAL, "HID Prox TAG ID: %x%08x (%u) - Format Len: %ubit - OEM: %03u - FC: %u - Card: %u",
+		                      hi, lo, cardnum, fmtLen, oem, fc, cardnum);
 	}
 
 	PrintAndLogEx(DEBUG, "DEBUG: HID idx: %d, Len: %d, Printing Demod Buffer:", idx, size);
@@ -384,7 +391,19 @@ static void calc34(uint16_t fc, uint32_t cardno, uint8_t *out){
 	// *lo = ((cardno & 0xFFFFF) << 1) | fc << 21; 
 	// *hi = (1 << 5) | ((fc >> 11) & 1);  
 // }
-static void calc37S(uint16_t fc, uint32_t cardno, uint8_t *out){
+static void calc36(uint8_t oem, uint16_t fc, uint32_t cardno, uint8_t *out){
+	// FC     1  - 16  - 16 bit
+	// cardno 17 - 33  - 16 bit
+	// oem    34 - 35  -  2 bit
+	// Odd  Parity  0th bit  1-18
+	// Even Parity 36th bit 19-35
+	uint8_t wiegand[34];
+	num_to_bytebits(fc, 16, wiegand);
+	num_to_bytebits(cardno & 0xFFFF, 16, wiegand + 16);
+	num_to_bytebits(oem, 2, wiegand + 32);
+	wiegand_add_parity_swapped(out, wiegand, sizeof(wiegand));
+}
+static void calc37S(uint16_t fc, uint64_t cardno, uint8_t *out){
 	// FC 2 - 17   - 16 bit  
 	// cardno 18 - 36  - 19 bit
 	// Even P1   1 - 19
@@ -412,13 +431,14 @@ static void calc37H(uint64_t cardno, uint8_t *out){
 	// *hi = (cardno >> 31);  
 // }
 
-void calcWiegand(uint8_t fmtlen, uint16_t fc, uint64_t cardno, uint8_t *bits){
+void calcWiegand(uint8_t fmtlen, uint16_t fc, uint64_t cardno, uint8_t *bits, uint8_t oem){
 	 uint32_t cn32 = (cardno & 0xFFFFFFFF);
 	 switch ( fmtlen ) {
 		case 26: calc26(fc, cn32, bits); break;
 		// case 33 : calc33(fc, cn32, bits); break;
 		case 34: calc34(fc, cn32, bits); break;
 		// case 35 : calc35(fc, cn32, bits); break;
+		case 36: calc36(oem, fc, cn32, bits); break;
 		case 37: calc37S(fc, cn32, bits); break;
 		case 38: calc37H(cardno, bits); break;
 		// case 40 : calc40(cardno, bits);	break;
@@ -444,13 +464,13 @@ int CmdHIDWiegand(const char *Cmd) {
 	fc = param_get32ex(Cmd, 1, 0, 10);
 	cardnum = param_get64ex(Cmd, 2, 0, 10);
 
-	uint8_t fmtlen[] = {26,33,34,35,37,38,40};
+	uint8_t fmtlen[] = {26,33,34,35,36,37,38,40};
 	
 	PrintAndLogEx(NORMAL, "HID | OEM | FC   | CN      |  Wiegand  |  HID Formatted");
 	PrintAndLogEx(NORMAL, "----+-----+------+---------+-----------+--------------------");
 	for (uint8_t i = 0; i < sizeof(fmtlen); i++){
 		memset(bits, 0x00, sizeof(bits));
-		calcWiegand( fmtlen[i], fc, cardnum, bs);
+		calcWiegand( fmtlen[i], fc, cardnum, bs, oem);
 		PrintAndLogEx(NORMAL, "ice:: %s \n", sprint_bin(bs, fmtlen[i]));
 		wiegand = (uint64_t)bytebits_to_byte(bs, 32) << 32 | bytebits_to_byte(bs+32, 32);
 		

--- a/client/cmdlfhid.h
+++ b/client/cmdlfhid.h
@@ -39,5 +39,5 @@ extern int usage_lf_hid_clone(void);
 extern int usage_lf_hid_brute(void);
 
 //void calc26(uint16_t fc, uint32_t cardno, uint8_t *out);
-extern void calcWiegand(uint8_t fmtlen, uint16_t fc, uint64_t cardno, uint8_t *bits);
+extern void calcWiegand(uint8_t fmtlen, uint16_t fc, uint64_t cardno, uint8_t *bits, uint8_t oem);
 #endif

--- a/client/util.c
+++ b/client/util.c
@@ -706,6 +706,15 @@ void wiegand_add_parity(uint8_t *target, uint8_t *source, uint8_t length)
     *(target)= GetParity(source + length / 2, ODD, length / 2);
 }
 
+// add HID parity to binary array: ODD prefix for 1st half of ID, EVEN suffix for 2nd half
+void wiegand_add_parity_swapped(uint8_t *target, uint8_t *source, uint8_t length)
+{
+    *(target++)= GetParity(source, ODD, length / 2);
+    memcpy(target, source, length);
+    target += length;
+    *(target)= GetParity(source + length / 2, EVEN, length / 2);
+}
+
 // xor two arrays together for len items.  The dst array contains the new xored values.
 void xor(unsigned char * dst, unsigned char * src, size_t len) {
    for( ; len > 0; len--,dst++,src++)

--- a/client/util.h
+++ b/client/util.h
@@ -233,6 +233,7 @@ extern int binarraytohex( char *target,  char *source,  int length);
 extern void binarraytobinstring(char *target,  char *source,  int length);
 extern uint8_t GetParity( uint8_t *string, uint8_t type,  int length);
 extern void wiegand_add_parity(uint8_t *target, uint8_t *source, uint8_t length);
+extern void wiegand_add_parity_swapped(uint8_t *target, uint8_t *source, uint8_t length);
 
 extern void xor(unsigned char * dst, unsigned char * src, size_t len);
 extern int32_t le24toh (uint8_t data[3]);


### PR DESCRIPTION
I came across a bag full of HID tags using this format that I couldn't find documented anywhere. After some poking and prodding at the bits I worked out the format and figured I would contribute the addition. I added support to the demoudulator, tested reading, cloning, wiegand output, and simulation. I did not add support for this format to the brute forcer as it would require refactoring to support the OEM segment, and just hard coded a 0 into the OEM parameter added to `clacWiegand` inside the brute forcing code.

This format is backwards in that the parity logic is swapped, so I duplicated the existing function to do this. Plenty of head scratching to finally figure that out as none of the other HID formats seem to be encoded this way.

Format Details:
```
FC     1  - 16  - 16 bit
cardno 17 - 33  - 16 bit
oem    34 - 35  -  2 bit
Odd  Parity  0th bit  1-17
Even Parity 36th bit 18-35
```
Some example bitstreams, card number is printed on tag along with sales order number from original purchase:
```
1 1011000000010000 0101101110100000 00 1 FC = 45072, Card = 23456, OEM = 0
1 1011000000010000 0101101111000001 00 0 FC = 45072, Card = 23489, OEM = 0
1 1011000000010000 0101101111100111 00 1 FC = 45072, Card = 23527, OEM = 0
1 1011000000010000 0110000100000100 00 0 FC = 45072, Card = 24836, OEM = 0
1 1011000000010000 0110000000110001 00 1 FC = 45072, Card = 24625, OEM = 0
```