### PR TITLE
Fix 14443 typos

### DIFF
--- a/armsrc/iso14443b.c
+++ b/armsrc/iso14443b.c
@@ -1255,7 +1255,7 @@ uint8_t iso14443b_select_card(iso14b_card_select_t *card ) {
 	
 	// VALIDATE CRC
 	if (!check_crc(CRC_14443_B, Demod.output, Demod.len)) {
-		if (MF_DBGLEVEL > 3) Dbprintf("iso1443b_setup crc fail");
+		if (MF_DBGLEVEL > 3) Dbprintf("iso14443b_setup crc fail");
 		return 3;
 	}
 	
@@ -1280,7 +1280,7 @@ uint8_t iso14443b_select_card(iso14b_card_select_t *card ) {
 
 	// VALIDATE CRC
 	if (!check_crc(CRC_14443_B, Demod.output, Demod.len) ) {
-		if (MF_DBGLEVEL > 3) Dbprintf("iso1443b_setup crc2 fail");
+		if (MF_DBGLEVEL > 3) Dbprintf("iso14443b_setup crc2 fail");
 		return 3;
 	}
 
@@ -1314,7 +1314,7 @@ uint8_t iso14443b_select_card(iso14b_card_select_t *card ) {
 // Set up ISO 14443 Type B communication (similar to iso14443a_setup)
 // field is setup for "Sending as Reader"
 void iso14443b_setup() {
-	if (MF_DBGLEVEL > 3) Dbprintf("iso1443b_setup Enter");
+	if (MF_DBGLEVEL > 3) Dbprintf("iso14443b_setup Enter");
 	LEDsoff();
 	FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
 	//BigBuf_free();
@@ -1338,7 +1338,7 @@ void iso14443b_setup() {
 	StartCountSspClk();
 	
 	LED_D_ON();
-	if (MF_DBGLEVEL > 3) Dbprintf("iso1443b_setup Exit");
+	if (MF_DBGLEVEL > 3) Dbprintf("iso14443b_setup Exit");
 }
 
 //-----------------------------------------------------------------------------
@@ -1471,7 +1471,7 @@ void ReadSTMemoryIso14443b(uint8_t numofblocks) {
 }
 
 static void iso1444b_setup_sniff(void){
-	if (MF_DBGLEVEL > 3) Dbprintf("iso1443b_setup_sniff Enter");
+	if (MF_DBGLEVEL > 3) Dbprintf("iso14443b_setup_sniff Enter");
 	LEDsoff();
 	FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
 	BigBuf_free();
@@ -1505,7 +1505,7 @@ static void iso1444b_setup_sniff(void){
 	// Start the SSP timer
 	StartCountSspClk();
 
-	if (MF_DBGLEVEL > 3) Dbprintf("iso1443b_setup_sniff Exit");
+	if (MF_DBGLEVEL > 3) Dbprintf("iso14443b_setup_sniff Exit");
 }
 
 //=============================================================================

--- a/client/lualibs/hf_reader.lua
+++ b/client/lualibs/hf_reader.lua
@@ -21,13 +21,7 @@ local function sendToDevice(command, ignoreresponse)
 	return response,nil
 end
 
--------------------------------------------------------
--- This will be moved to a separate 14443B library
--------------------------------------------------------
 
-local reader14443B = {
-	read = reader14443B.read14443b()
-}	
 -------------------------------------------------------
 -- This will be moved to a separate 1593 library
 -------------------------------------------------------

--- a/client/lualibs/read14a.lua
+++ b/client/lualibs/read14a.lua
@@ -67,7 +67,7 @@ local function parse14443a(data)
 	local count, uid, uidlen, atqa, sak, ats_len, ats = bin.unpack('H10CH2CC',data)
 	uid = uid:sub(1, 2*uidlen)
 	--print("uid, atqa, sak: ",uid, atqa, sak)
-	--print("TYPE: ", tostring_1443a(sak))
+	--print("TYPE: ", tostring_14443a(sak))
 	return { uid = uid, atqa  = atqa, sak = sak, name = tostring_14443a(sak), data = data}
 end
 
@@ -141,7 +141,7 @@ local function waitFor14443a()
 end
 local library = {
 	read = read14443a,
-	read 	= read14443a,
+	read14443a = read14443a,
 	waitFor14443a = waitFor14443a,
 	parse14443a = parse14443a,
 	sendToDevice = sendToDevice,

--- a/client/lualibs/read14b.lua
+++ b/client/lualibs/read14b.lua
@@ -2,7 +2,7 @@
 	This is a library to read 14443b tags. It can be used something like this
 
 	local reader = require('read14b')
-	result, err = reader.select1443b()
+	result, err = reader.select14443b()
 	if not result then
 		print(err)
 		return
@@ -25,7 +25,7 @@ local ISO14B_COMMAND = {
 	ISO14B_SELECT_SR = 0x80,
 }
 
-local function parse1443b(data)
+local function parse14443b(data)
 	--[[
 	
 	Based on this struct : 
@@ -101,7 +101,7 @@ local function read14443b(disconnect)
 		local count,cmd,arg0,arg1,arg2 = bin.unpack('LLLL',result)
 		if arg0 == 0 then 
 			data = string.sub(result, count)
-			info, err = parse1443b(data)
+			info, err = parse14443b(data)
 		else
 			err = "iso14443b card select failed"
 		end
@@ -147,8 +147,11 @@ local function waitFor14443b()
 end
 
 local library = {
-	parse1443b  = parse1443b,
-	read1443b 	= read14443b,
+	parse14443b = parse14443b,
+	parse1443b = parse14443b,
+	read = read14443b,
+	read14443b = read14443b,
+	read1443b = read14443b,
 	waitFor14443b = waitFor14443b,
 	sendToDevice = sendToDevice,
 	showData = showData,

--- a/client/scripts/amiibo.lua
+++ b/client/scripts/amiibo.lua
@@ -196,7 +196,7 @@ local function main(args)
       return
    end
 
-   parsed_tag = reader.parse1443a(tag)
+   parsed_tag = reader.parse14443a(tag)
    print('Tag type:', parsed_tag.name)
    print('Tag UID:', parsed_tag.uid)
    print('Tag len:', tag:len())


### PR DESCRIPTION
Replaces several instances of _1443_ with _14443_ that have been causing issues with the Lua libraries.
Updates public method/alias targets to renamed local methods for backwards compatibility.

Moves _read_ alias from _hf_reader_ (override) to _read14b_ library to fix compatibility with _hf_reader_. 