### PR TITLE
Added some Vigik keys to default keys

### DIFF
--- a/client/default_keys.dic
+++ b/client/default_keys.dic
@@ -611,3 +611,24 @@ C01FC822C6E5
 # More keys:
 8a19d40cf2b5
 ae8587108640
+#
+# Following keys were extracted from the ScanBadge Android app (fr.badgevigik.scanbadge)
+# Creators claims it should cover most Vigik vendors and implementations
+# Intratone, Comelit, Urmet, Hexact, Noralsy, Bitron, Bticino, CDVI, HID, Immotec, Aiphone
+4a4c474f524d
+444156494442
+434143445649
+434456495243
+a00002000021
+ef61a3d48e2a
+a23456789123
+010000000000
+363119000001
+a00003000084
+4143414f5250
+4243414f5250
+675a32413770
+395244733978
+a0004a000036
+2c9f3d45ba13
+dfe73be48ac6


### PR DESCRIPTION
A french Android app (https://play.google.com/store/apps/details?id=fr.badgevigik.scanbadge) allows people to scan their own badge with their phones to automatically dump the content of the badge and upload it to a company that provide a cloning service for Vigik key fobs.

The PR adds the keys I extracted from the APK to the default_keys.dic that weren't already present : )